### PR TITLE
mail: Refactor client tests.

### DIFF
--- a/politeiawww/mail/client.go
+++ b/politeiawww/mail/client.go
@@ -122,8 +122,8 @@ func (c *client) SendToUsers(subjects, body string, recipients map[uuid.UUID]str
 // reply.
 //
 // If a user has previously hit the rate limit, but a full rate limit period
-// has passed since then, their email history is reset and they will be
-// included in the reply.
+// has passed, their email history is reset and they will be included in the
+// reply.
 type filteredRecipients struct {
 	// valid contains the email addresses of the users that have not
 	// hit the email rate limit and are eligible to receive an email.

--- a/politeiawww/mail/client.go
+++ b/politeiawww/mail/client.go
@@ -117,8 +117,13 @@ func (c *client) SendToUsers(subjects, body string, recipients map[uuid.UUID]str
 
 // filteredRecipients is returned by the filteredRecipients function and
 // contains the recipients that should receive some sort of email notification.
+//
 // Users that have already hit the email rate limit are not included in this
 // reply.
+//
+// If a user has previously hit the rate limit, but a full rate limit period
+// has passed since then, their email history is reset and they will be
+// included in the reply.
 type filteredRecipients struct {
 	// valid contains the email addresses of the users that have not
 	// hit the email rate limit and are eligible to receive an email.

--- a/politeiawww/mail/client_test.go
+++ b/politeiawww/mail/client_test.go
@@ -115,21 +115,25 @@ func TestFilterRecipients(t *testing.T) {
 		t.Errorf("user with no email history was not found in the "+
 			"valid emails list: %v", fr.valid)
 	}
+
 	_, ok = valid[emailUnderLimit]
 	if !ok {
 		t.Errorf("user with email history under the rate limit was "+
 			"not found in the valid emails list: %v", fr.valid)
 	}
+
 	_, ok = valid[emailNearLimit]
 	if !ok {
 		t.Errorf("user with email history under the rate limit by 1 "+
 			"was not found in the valid emails list: %v", fr.valid)
 	}
+
 	_, ok = valid[emailAtLimitExpired]
 	if !ok {
 		t.Errorf("user with email history at the rate limit but expired "+
 			"was not found in the valid emails list: %v", fr.valid)
 	}
+
 	if len(fr.valid) != 4 {
 		t.Errorf("valid emails list length want 4, got %v: %v",
 			len(fr.valid), fr.valid)

--- a/politeiawww/user/mail.go
+++ b/politeiawww/user/mail.go
@@ -28,8 +28,12 @@ type MailerDB interface {
 // transactions, and email notifications run in a separate goroutine. This
 // workaround won't be necessary once the user layer gets rewritten.
 type EmailHistory struct {
-	Timestamps       []int64 `json:"timestamps"` // Received email UNIX ts
-	LimitWarningSent bool    `json:"limitwarningsent"`
+	Timestamps []int64 `json:"timestamps"` // Received email UNIX ts
+
+	// LimitWarningSent is used to track users that have hit the rate
+	// limit and have already been sent a notification email letting
+	// them know that they hit the rate limit.
+	LimitWarningSent bool `json:"limitwarningsent"`
 }
 
 // VersionEmailHistory is the version of the EmailHistory struct.

--- a/politeiawww/user/mailtest.go
+++ b/politeiawww/user/mailtest.go
@@ -10,20 +10,32 @@ import (
 	"github.com/google/uuid"
 )
 
-// TestMailerDB implements the MailerDB interface that is used for testing
+// testMailerDB implements the MailerDB interface that is used for testing
 // purposes. It saves and retrieves data in memory to emulate the behaviour
 // needed to test the mail package.
-type TestMailerDB struct {
+type testMailerDB struct {
 	sync.RWMutex
 
 	Histories map[uuid.UUID]EmailHistory
+}
+
+// NewTestMailerDB returns a new testMailerDB. The caller can optionally
+// provide a list of email histories to seed the testMailerDB with on
+// intialization.
+func NewTestMailerDB(histories map[uuid.UUID]EmailHistory) *testMailerDB {
+	if histories == nil {
+		histories = make(map[uuid.UUID]EmailHistory, 1024)
+	}
+	return &testMailerDB{
+		Histories: histories,
+	}
 }
 
 // EmailHistoriesSave implements the save function using the in memory cache
 // for testing purposes.
 //
 // This function satisfies the MailerDB interface.
-func (m *TestMailerDB) EmailHistoriesSave(histories map[uuid.UUID]EmailHistory) error {
+func (m *testMailerDB) EmailHistoriesSave(histories map[uuid.UUID]EmailHistory) error {
 	m.Lock()
 	defer m.Unlock()
 
@@ -38,7 +50,7 @@ func (m *TestMailerDB) EmailHistoriesSave(histories map[uuid.UUID]EmailHistory) 
 // for testing purposes.
 //
 // This function satisfies the MailerDB interface.
-func (m *TestMailerDB) EmailHistoriesGet(users []uuid.UUID) (map[uuid.UUID]EmailHistory, error) {
+func (m *testMailerDB) EmailHistoriesGet(users []uuid.UUID) (map[uuid.UUID]EmailHistory, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -53,11 +65,4 @@ func (m *TestMailerDB) EmailHistoriesGet(users []uuid.UUID) (map[uuid.UUID]Email
 		histories[userID] = h
 	}
 	return histories, nil
-}
-
-// NewTestMailerDB returns a new TestMailerDB instance.
-func NewTestMailerDB() *TestMailerDB {
-	return &TestMailerDB{
-		Histories: make(map[uuid.UUID]EmailHistory, 5),
-	}
 }


### PR DESCRIPTION
This diff refactors the `mail/client.go` tests and adds additional
documentation to the `client.go` file.  There were a couple issues with
the previous implemenation.

**Documentation**

Some of the documentation was still not clear enough about bevahior and
edge cases.  These documentation changes should server as an example of
the detail and clarity of thought that I would like to see in all future
pull requests.

**testMailerDB**

The `testMailerDB` struct is implementing a interface so it does not
need to be exported directly. Just the `NewTestMailerDB` initialization
function needs to be exported.

An argument was also added to `NewTestMailerDB` to allow the caller to
seed the `MailerDB` with data on initialization.

**TestFilterRecipeints**

I refactored the `TestFilterRecipeints` function. Table driven tests are
good for API where you need to test various input/output and expected
error paths (ex. user errors in the politeiawww API).  The function
`filterRecipeints()` really only has one code path that needed to be
tested, but the output of this code path could be quite complex. I found
it easier to use a single test where I could examine the output in more
detail depending on the input rather than have a table driven test setup
where the output checks were generic. This just highlights that no
solution is one size fits all and sometimes its better to deviate from
the standard practices.

The important cases to test are:
- User with no prior history
- User under the rate limit by more than 1
- User under the rate limit by 1 and will hit the rate limit in the next
  invocation
- User at the rate limit with the warning email sent whose timestamps
  were within the past rate limit period
- User at the rate limit with the warning email sent whose timestamps
  are now expired and should now be reset

Writing these tests uncovered some unnecessary complexity. A user was
not being sent a rate limit warning email when they hit the rate limit.
They were being sent a rate limit email when they hit the rate limit + 1.

This was confusing. The behavior that I would expect is that they are
sent the rate limit warning email when they actually hit the rate limit.
For example:
- The user hits the 100 email rate limit
- They are sent both the 100th notification email and the rate limit
  warning email
- They are not sent any additional emails for the duration of one rate
  limit period

You'll notice that there are currently two tests failing. These tests expect
the behavior I described. 

```
    client_test.go:148: user that hit the rate limit was not found in the warning emails list: []
    client_test.go:200: limit warning sent for user with email history under the rate limit by one: want true, got false
```

The implemenation should be updated so that these tests are passing.

These tests are also written in a way that are cleaner, easier to read,
and better document than the previous tests. Its kind of hard to tell by
looking at the pull request diff, but if you look at the file you'll see
a big difference.  Please use this as an example for future pull
requests for how I would like code to be written.
